### PR TITLE
Added Bash script to build bin files using CC65 - parallels batch script

### DIFF
--- a/ca65/asm_cmp.sh
+++ b/ca65/asm_cmp.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+FILE=$1
+ca65 -l $FILE.lst $FILE.ca65
+ld65 $FILE.o -o $FILE.bin -m $FILE.map -C example.cfg
+


### PR DESCRIPTION
I created this as I develop on macOS, and found the script to be useful while building my own MOS-6502 emulator.  It's an almost direct parallel with the batch script in the same directory (minus the file comparison).

I'm thinking this may be useful for Linux/Unix users, using a Bash shell.